### PR TITLE
cargo: add "derive" feature in clap dependency

### DIFF
--- a/rjs/Cargo.toml
+++ b/rjs/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Jason Ish <jish@oisf.net>"]
 
 [dependencies]
 suricata-rule-parser = { path = ".." }
-clap = "3.0.0-beta.5"
+clap = { version = "3.0.0-beta.5", features = ["derive"] }
 serde = "1.0.130"
 serde_yaml = "0.8.21"
 serde_json = "1.0.69"


### PR DESCRIPTION
If clap is compiled with the derive feature enabled, the `rjs` example fails to build with:
```
error[E0433]: failed to resolve: could not find `Parser` in `clap`
  --> rjs/src/main.rs:31:16
   |
31 | #[derive(clap::Parser)]
   |                ^^^^^^ could not find `Parser` in `clap`
```